### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a SAP SuccessFactors connector
 og:title: Set up a SAP SuccessFactors connector - C1 docs
-og:description: Integrate your SAP SuccessFactors instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for SAP SuccessFactors. Integrate your SuccessFactors instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for SAP SuccessFactors. Integrate your SAP SuccessFactors instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for SAP SuccessFactors. Integrate your SAP SuccessFactors instance with C1 for unified visibility and governance over user access."
 sidebarTitle: SAP SuccessFactors
 ---
 
@@ -97,7 +97,7 @@ Carefully copy and save the API key. When setting up the connector, you'll use t
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the SuccessFactors connector
 
@@ -169,7 +169,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your SuccessFactors connector is now pulling access data into C1.
+**Done.** Your SuccessFactors connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the SuccessFactors connector, hosted and run in your own environment.**
@@ -289,7 +289,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your SuccessFactors connector is now pulling access data into C1.
+**Done.** Your SuccessFactors connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines