### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -268,7 +268,7 @@ spec:
     spec:
       containers:
       - name: baton-successfactors
-        image: ghcr.io/conductorone/baton-successfactors:latest
+        image: public.ecr.aws/conductorone/baton-successfactors:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -292,6 +292,3 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 **Done.** Your SuccessFactors connector is now pulling access data into C1.
 </Tab>
 </Tabs>
-
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made (as applicable):**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._