### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -77,8 +77,6 @@ func userResource(user client.Results) (*v2.Resource, error) {
 	}
 
 	userTraitOptions := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
-		resource.WithStatus(status),
 		resource.WithUserLogin(user.UserNav.Username),
 		resource.WithEmail(user.UserNav.Email, true),
 	}
@@ -87,6 +85,8 @@ func userResource(user client.Results) (*v2.Resource, error) {
 		resourceTypeUser,
 		user.UserNav.Username,
 		userTraitOptions,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(status), ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
